### PR TITLE
fix: custom-cmd invalid while cmd with spaces

### DIFF
--- a/lib/custom_cmd.js
+++ b/lib/custom_cmd.js
@@ -151,6 +151,7 @@ function _reply(_event, _bot) {
 
 	if(gCustomCMD[sIdx] == undefined) return false;
 
+	msg = msg.trim();
 	if (gCustomCMD[sIdx].includes(msg) == false){ 
 		// 傳進來指令在自訂指令裏面沒有的話，就 reutrn
 		return false;


### PR DESCRIPTION
使用者指令進來，如果後面有空格，會造成無法啟動客製化指令效果。
用@xxxx 去標註的話，Line APP會自動在後面加上空格所致。